### PR TITLE
Fix adapter check error message

### DIFF
--- a/lib/rspec/rails/matchers/action_cable.rb
+++ b/lib/rspec/rails/matchers/action_cable.rb
@@ -188,7 +188,7 @@ module RSpec
       # @private
       def check_action_cable_adapter
         return if ::ActionCable::SubscriptionAdapter::Test === ::ActionCable.server.pubsub
-        raise StandardError, "To use ActionCable matchers set `adapter: :test` in your cable.yml"
+        raise StandardError, "To use ActionCable matchers set `adapter: test` in your cable.yml"
       end
     end
   end

--- a/spec/rspec/rails/matchers/action_cable_spec.rb
+++ b/spec/rspec/rails/matchers/action_cable_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe "ActionCable matchers", :skip => !RSpec::Rails::FeatureCheck.has_
       ActionCable.server.instance_variable_set(:@pubsub, ActionCable::SubscriptionAdapter::Inline)
       expect {
         expect { broadcast('stream', 'hello') }.to have_broadcasted_to('stream')
-      }.to raise_error("To use ActionCable matchers set `adapter: :test` in your cable.yml")
+      }.to raise_error("To use ActionCable matchers set `adapter: test` in your cable.yml")
     end
 
     it "fails with with block with incorrect data" do


### PR DESCRIPTION
PR fixes misleading error message. As seen [here](https://github.com/rails/rails/blob/master/actioncable/lib/action_cable/server/configuration.rb#L50), config expects adapter to be a string 