### PR TITLE
Use ActionCable::Connection::TaggedLoggerProxy

### DIFF
--- a/lib/action_cable/connection/test_case.rb
+++ b/lib/action_cable/connection/test_case.rb
@@ -55,7 +55,9 @@ module ActionCable
       attr_reader :logger, :request
 
       def initialize(path, cookies, headers)
-        @logger = ActiveSupport::TaggedLogging.new ActiveSupport::Logger.new(StringIO.new)
+        inner_logger = ActiveSupport::Logger.new(StringIO.new)
+        tagged_logging = ActiveSupport::TaggedLogging.new(inner_logger)
+        @logger = ActionCable::Connection::TaggedLoggerProxy.new(tagged_logging, tags: [])
 
         uri = URI.parse(path)
         env = {

--- a/test/connection/test_case_test.rb
+++ b/test/connection/test_case_test.rb
@@ -59,6 +59,7 @@ class Connection < ActionCable::Connection::Base
   def connect
     self.current_user_id = verify_user
     self.token = request.headers["X-API-TOKEN"]
+    logger.add_tags("ActionCable")
   end
 
   private


### PR DESCRIPTION
ActionCable::Connection uses TaggedLoggerProxy to support tags across long lived connections. If the connection under test attempted to call methods such as `add_tags` that are unique to TaggedLoggerProxy it would get an error, as the provided TestConnection wasn't using TaggedLoggerProxy.

This commit corrects that, allowing the connection under test to call all available logger methods.