### PR TITLE
Added encrypted cookies

### DIFF
--- a/lib/action_cable/connection/test_case.rb
+++ b/lib/action_cable/connection/test_case.rb
@@ -38,8 +38,13 @@ module ActionCable
       attr_reader :cookie_jar
 
       module CookiesStub
-        # Stub signed cookies, we don't need to test encryption here
+        # Stub signed cookies
         def signed
+          self
+        end
+
+        # Stub encrypted cookies
+        def encrypted
           self
         end
       end

--- a/test/connection/test_case_test.rb
+++ b/test/connection/test_case_test.rb
@@ -82,3 +82,31 @@ class ConnectionTest < ActionCable::Connection::TestCase
     assert_reject_connection { connect }
   end
 end
+
+class EncryptedCookiesConnection < ActionCable::Connection::Base
+  identified_by :user_id
+
+  def connect
+    self.user_id = verify_user
+  end
+
+  private
+
+    def verify_user
+      reject_unauthorized_connection unless cookies.encrypted[:user_id].present?
+      cookies.encrypted[:user_id]
+    end
+end
+
+class EncryptedCookiesConnectionTest < ActionCable::Connection::TestCase
+  tests EncryptedCookiesConnection
+
+  def test_connected_with_encrypted_cookies
+    connect cookies: { user_id: "789" }
+    assert_equal "789", connection.user_id
+  end
+
+  def test_connection_rejected
+    assert_reject_connection { connect }
+  end
+end


### PR DESCRIPTION
I want to use [encrypted cookies](https://api.rubyonrails.org/v5.2.1/classes/ActionDispatch/Cookies.html) in a connection of action cable. So added `encrypted` method to `CookiesStub`.
Please check it out.
