### PR TITLE
add system tests to feature tests context include

### DIFF
--- a/lib/action_cable/testing/rspec/features.rb
+++ b/lib/action_cable/testing/rspec/features.rb
@@ -2,5 +2,5 @@
 
 # Use async adapter for features specs by deafault
 RSpec.configure do |config|
-  config.include_context "action_cable:async", type: :feature
+  config.include_context "action_cable:async", type: [:feature, :system]
 end


### PR DESCRIPTION
Rails 5 now supports system/feature tests out the box, there type is`system` this simply allows the feature contexts to be activated for system tests.