### PR TITLE
Return direct access to streams and mark it as deprecated

### DIFF
--- a/lib/action_cable/channel/test_case.rb
+++ b/lib/action_cable/channel/test_case.rb
@@ -159,6 +159,13 @@ module ActionCable
 
           attr_reader :subscription
 
+          def streams
+            ActiveSupport::Deprecation.warn "Use appropriate `assert_has_stream`, `assert_has_stream_for`, `assert_no_streams` " +
+              "assertion methods for minitest or `have_stream`, `have_stream_for` and `have_stream_from` matchers " +
+              "for RSpec. Direct access to `streams` is deprecated and is going to be removed in version 1.0"
+            subscription.streams
+          end
+
           ActiveSupport.run_load_hooks(:action_cable_channel_test_case, self)
         end
 

--- a/spec/rspec/rails/matchers/action_cable/have_stream_spec.rb
+++ b/spec/rspec/rails/matchers/action_cable/have_stream_spec.rb
@@ -180,4 +180,18 @@ RSpec.describe "have_streams matchers" do
       end
     end
   end
+
+  if Gem::Version.new(ActionCable::Testing::VERSION) < Gem::Version.new("1.0")
+    specify { expect(self).to respond_to(:streams) }
+
+    it "passes" do
+      subscribe id: 1
+
+      ActiveSupport::Deprecation.silence do
+        expect(streams).to include("chat_1")
+      end
+    end
+  else
+    specify { expect(self).not_to respond_to(:streams) }
+  end
 end


### PR DESCRIPTION
It turns out that we made a backward-incompatible change in #42. It could be confusing. I propose to return it back and mark it for deprecation in 1.0 version according to the conventions.