### PR TITLE
Fix typo

### DIFF
--- a/lib/action_cable/test_helper.rb
+++ b/lib/action_cable/test_helper.rb
@@ -3,7 +3,7 @@
 module ActionCable
   # Provides helper methods for testing Action Cable broadcasting
   module TestHelper
-    CHANNEL_NOT_FOUND = ArgumentError.new("Broadcastnig channel can't be infered. Please, specify it with `:channel`")
+    CHANNEL_NOT_FOUND = ArgumentError.new("Broadcasting channel can't be infered. Please, specify it with `:channel`")
 
     def before_setup # :nodoc:
       server = ActionCable.server

--- a/lib/rspec/rails/matchers/action_cable/have_broadcasted_to.rb
+++ b/lib/rspec/rails/matchers/action_cable/have_broadcasted_to.rb
@@ -160,7 +160,7 @@ module RSpec
           def check_channel_presence
             return if @channel.present? && @channel.respond_to?(:channel_name)
 
-            error_msg = "Broadcastnig channel can't be infered. Please, specify it with `from_channel`"
+            error_msg = "Broadcasting channel can't be infered. Please, specify it with `from_channel`"
             raise ArgumentError, error_msg
           end
         end


### PR DESCRIPTION
Just fix a spelling mistake, `Broadcastnig` => `Broadcasting`