### PR TITLE
Handle RSpec 4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,7 +48,7 @@ Layout/EmptyLinesAroundMethodBody:
 Layout/EmptyLinesAroundModuleBody:
   Enabled: true
 
-Layout/FirstParameterIndentation:
+Layout/IndentFirstArgument:
   Enabled: true
 
 # Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 cache: bundler
 
 before_install:
-  - gem update --system
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
   - gem install bundler -v '< 2'
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ matrix:
     - rvm: ruby-head
       gemfile: Gemfile
     - rvm: 2.6
+      gemfile: gemfiles/rspec4rails6.gemfile
+    - rvm: 2.6
+      gemfile: gemfiles/rspec4rails5.gemfile
+    - rvm: 2.6
       gemfile: Gemfile
     - rvm: 2.6
       gemfile: gemfiles/rails6.gemfile

--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@
 
 This gem provides missing testing utils for [Action Cable][].
 
-**NOTE:** this gem [has](https://github.com/rails/rails/pull/33659) [been](https://github.com/rails/rails/pull/33969) [merged](https://github.com/rails/rails/pull/34845) into Rails 6.0.
+**NOTE:** this gem [has](https://github.com/rails/rails/pull/33659) [been](https://github.com/rails/rails/pull/33969) [merged](https://github.com/rails/rails/pull/34845) into Rails 6.0 and [into RSpec 4](https://github.com/rspec/rspec-rails/pull/2113).
 
 If you're using Minitest – you don't need this gem anymore.
 
 If you're using RSpec < 4, you still can use this gem to write Action Cable specs even for Rails 6.
-
 
 ## Installation
 
@@ -336,6 +335,8 @@ end
 **NOTE:** for connections testing you must use `type: :channel` too.
 
 #### Shared contexts to switch between adapters
+
+**NOTE:** this feature is gem-only and hasn't been migrated to RSpec 4. You can still use the gem for that by adding `require "rspec/rails/shared_contexts/action_cable"` to your `rspec_helper.rb`.
 
 Sometimes you may want to use _real_ Action Cable adapter instead of the test one (for example, in Capybara-like tests).
 

--- a/action-cable-testing.gemspec
+++ b/action-cable-testing.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "aruba", "~> 0.14.6"
   spec.add_development_dependency "minitest", "~> 5.9"
   spec.add_development_dependency "ammeter", "~> 1.1"
-  spec.add_development_dependency "rubocop", "~> 0.51"
+  spec.add_development_dependency "rubocop", "~> 0.68.0"
 end

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -19,7 +19,7 @@ Then /^the example(s)? should( all)? fail/ do |_, _|
 end
 
 Given /action cable is available/ do
-  if !RSpec::Rails::FeatureCheck.has_action_cable?
+  if !RSpec::Rails::FeatureCheck.has_action_cable_testing?
     pending "Action Cable is not available"
   end
 end

--- a/gemfiles/rspec4rails5.gemfile
+++ b/gemfiles/rspec4rails5.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem "rails", "~> 5.2"
+gem "rspec-rails", github: "rspec/rspec-rails", branch: "4-0-dev"
+
+gemspec path: '..'

--- a/gemfiles/rspec4rails6.gemfile
+++ b/gemfiles/rspec4rails6.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem "rails", "6.0.0.beta1"
+gem "rspec-rails", github: "rspec/rspec-rails", branch: "4-0-dev"
+
+gemspec path: '..'

--- a/lib/action_cable/testing/rspec.rb
+++ b/lib/action_cable/testing/rspec.rb
@@ -2,25 +2,38 @@
 
 require "action-cable-testing"
 require "rspec/rails"
-require "rspec/rails/example/channel_example_group"
-require "rspec/rails/matchers/action_cable"
-require "rspec/rails/shared_contexts/action_cable"
 
-module RSpec # :nodoc:
-  module Rails
-    module FeatureCheck
-      module_function
-        def has_action_cable?
-          defined?(::ActionCable)
-        end
+if RSpec::Rails::FeatureCheck.respond_to?(:has_action_cable_testing?)
+  warn <<~MSG
+    You're using RSpec with Action Cable support.
+
+    You can remove `require "action_cable/testing/rspec"` from your RSpec setup.
+
+    NOTE: if you use Action Cable shared contexts ("action_cable:async", "action_cable:inline", etc.)
+    you still need to use the gem and add `require "rspec/rails/shared_contexts/action_cable"`.
+  MSG
+else
+  require "rspec/rails/example/channel_example_group"
+  require "rspec/rails/matchers/action_cable"
+
+  module RSpec # :nodoc:
+    module Rails
+      module FeatureCheck
+        module_function
+          def has_action_cable_testing?
+            defined?(::ActionCable)
+          end
+      end
+
+      self::DIRECTORY_MAPPINGS[:channel] = %w[spec channels]
     end
+  end
 
-    self::DIRECTORY_MAPPINGS[:channel] = %w[spec channels]
+  RSpec.configure do |config|
+    if defined?(ActionCable)
+      config.include RSpec::Rails::ChannelExampleGroup, type: :channel
+    end
   end
 end
 
-RSpec.configure do |config|
-  if defined?(ActionCable)
-    config.include RSpec::Rails::ChannelExampleGroup, type: :channel
-  end
-end
+require "rspec/rails/shared_contexts/action_cable"

--- a/spec/rspec/rails/matchers/action_cable/have_broadcasted_to_spec.rb
+++ b/spec/rspec/rails/matchers/action_cable/have_broadcasted_to_spec.rb
@@ -1,11 +1,11 @@
 require "spec_helper"
 require "rspec/rails/feature_check"
 
-if RSpec::Rails::FeatureCheck.has_action_cable?
+if RSpec::Rails::FeatureCheck.has_action_cable_testing?
   require "rspec/rails/matchers/action_cable"
 end
 
-RSpec.describe "have_broadcasted_to matchers", :skip => !RSpec::Rails::FeatureCheck.has_action_cable? do
+RSpec.describe "have_broadcasted_to matchers", :skip => !RSpec::Rails::FeatureCheck.has_action_cable_testing? do
   let(:channel) do
     Class.new(ActionCable::Channel::Base) do
       def self.channel_name


### PR DESCRIPTION
RSpec 4 [_acquired_](https://github.com/rspec/rspec-rails/pull/2113) `action-cable-testing`.

We need to handle this:
- If Rails < 6 is used we should provide the missing Rails parts (i.e. test cases) and not include RSpec integration
- if Rails 6 is used, we shouldn't load any code and print warning "You don't need action-cable-testing anymore"