### PR TITLE
expalins how to use with Rspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ RSpec.configure do |config|
 end
 ```
 
+(note in older versions of Rails you will make Rspec config changes in `spec_helper.rb`)
+
 ## Usage
 
 ### Test Adapter and Broadcasting

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ If you're using Minitest – you don't need this gem anymore.
 If you're using RSpec < 4, you still can use this gem to write Action Cable specs even for Rails 6.
 
 ## Installation
+# For Rails < 6.0 ONLY:
 
 Add this line to your application's Gemfile:
 
@@ -23,6 +24,15 @@ gem 'action-cable-testing'
 And then execute:
 
     $ bundle
+    
+# For Usage with Rspec (any version of Rails, including 6+):
+add to `spec/rails_helper.rb`
+```
+RSpec.configure do |config|
+ //more rspec configs...
+ config.include ActionCable::TestHelper
+end
+```
 
 ## Usage
 


### PR DESCRIPTION
the existing docs leave out the necessary require for the `rspec` config and make it sound like it is plug & play